### PR TITLE
Fix getfile endpoint

### DIFF
--- a/ZeroBounceSDK/ZeroBounce.cs
+++ b/ZeroBounceSDK/ZeroBounce.cs
@@ -243,7 +243,7 @@ namespace ZeroBounceSDK
 
             try
             {
-                var url = BulkApiBaseUrl + (scoring ? "/scoring" : "") + "/getFile?api_key=" + _apiKey + "&file_id=" + fileId;
+                var url = BulkApiBaseUrl + (scoring ? "/scoring" : "") + "/getfile?api_key=" + _apiKey + "&file_id=" + fileId;
                 var stream = await _client.GetStreamAsync(url);
                
                 var dirPath = Path.GetDirectoryName(localDownloadPath);


### PR DESCRIPTION
I believe the `getfile` endpoint has the same casing issue as fixed in commit d1fab3f52efaf99439eea76f0aacf8b317797e50