### PR TITLE
Feature request: Allow sending file with a Stream instead of filePath

### DIFF
--- a/ZeroBounceSDK/ZeroBounce.cs
+++ b/ZeroBounceSDK/ZeroBounce.cs
@@ -155,7 +155,27 @@ namespace ZeroBounceSDK
         public void ScoringSendFile(string filePath, SendFileOptions options,
             Action<ZBSendFileResponse> successCallback, Action<string> failureCallback)
         {
-            _SendFile(true, filePath, options, successCallback, failureCallback);
+            try
+            {
+                var fileName = Path.GetFileName(filePath);
+                var file = File.OpenRead(filePath);
+                _SendFile(true, file, fileName, options, successCallback, failureCallback);
+            }
+            catch (Exception e)
+            {
+                failureCallback(e.Message);
+            }
+        }
+
+        /// <summary>
+        /// The scoringSendfile API allows user to send a file for bulk email validation
+        /// <param name="successCallback"> The success callback function, called with a ZBSendFileResponse object</param>
+        /// <param name="failureCallback"> The failure callback function, called with a string error message</param>
+        /// </summary>
+        public void ScoringSendFile(Stream file, string fileName, SendFileOptions options,
+            Action<ZBSendFileResponse> successCallback, Action<string> failureCallback)
+        {
+            _SendFile(true, file, fileName, options, successCallback, failureCallback);
         }
 
         /// <summary>
@@ -166,10 +186,30 @@ namespace ZeroBounceSDK
         public void SendFile(string filePath, SendFileOptions options,
             Action<ZBSendFileResponse> successCallback, Action<string> failureCallback)
         {
-            _SendFile(false, filePath, options, successCallback, failureCallback);
+            try
+            {
+                var fileName = Path.GetFileName(filePath);
+                var file = File.OpenRead(filePath);
+                _SendFile(false, file, fileName, options, successCallback, failureCallback);
+            }
+            catch (Exception e)
+            {
+                failureCallback(e.Message);
+            }
         }
 
-        private async void _SendFile(bool scoring, string filePath, SendFileOptions options,
+        /// <summary>
+        /// The sendfile API allows user to send a file for bulk email validation
+        /// <param name="successCallback"> The success callback function, called with a ZBSendFileResponse object</param>
+        /// <param name="failureCallback"> The failure callback function, called with a string error message</param>
+        /// </summary>
+        public void SendFile(Stream file, string fileName, SendFileOptions options,
+            Action<ZBSendFileResponse> successCallback, Action<string> failureCallback)
+        {
+            _SendFile(false, file, fileName, options, successCallback, failureCallback);
+        }
+
+        private async void _SendFile(bool scoring, Stream file, string fileName, SendFileOptions options,
             Action<ZBSendFileResponse> successCallback, Action<string> failureCallback)
         {
             if (InvalidApiKey(failureCallback)) return;
@@ -177,8 +217,7 @@ namespace ZeroBounceSDK
             try
             {
                 var content = new MultipartFormDataContent();
-                var file = File.OpenRead(filePath);
-                content.Add(new StreamContent(file), "file", Path.GetFileName(filePath));
+                content.Add(new StreamContent(file), "file", fileName);
 
                 content.Add(new StringContent(_apiKey), "api_key");
 


### PR DESCRIPTION
Feel free to close this if the change is unwanted, I thought it could be useful though.

Currently when sending a file, a `filePath` is required so there has to be a saved file to read from. I believe it would also be useful to be able to provide a `Stream`, for example in use cases such as:
- Creating the CSV file in memory without having it saved to disk.
- Accepting an uploaded file on a server and passing the stream in directly without first saving it to disk.

I've added an overload for the existing methods that takes a Stream and file name